### PR TITLE
feat(printposition): add print position commands to escpos package

### DIFF
--- a/escpos/common/utils.go
+++ b/escpos/common/utils.go
@@ -31,11 +31,8 @@ func IsBufLenOk(buf []byte) error {
 }
 
 // LengthLowHigh convierte una longitud en dos bytes little-endian (dL,dH) para usar en comandos ESCPOS.
-func LengthLowHigh(length int) (dL, dH byte, err error) {
-	if length < 0 || length > 0xFFFF {
-		return 0, 0, ErrLengthOutOfRange
-	}
+func LengthLowHigh(length uint16) (dL, dH byte) {
 	dL = byte(length & 0xFF)        // byte de menor peso
 	dH = byte((length >> 8) & 0xFF) // byte de mayor peso
-	return dL, dH, nil
+	return dL, dH
 }

--- a/escpos/common/utils_test.go
+++ b/escpos/common/utils_test.go
@@ -30,27 +30,21 @@ func TestUtils_IsBufOk_ValidInput(t *testing.T) {
 
 func TestUtils_LengthLowHigh_ValidInput(t *testing.T) {
 	tests := []struct {
-		length  int
-		wantDL  byte
-		wantDH  byte
-		wantErr error
+		length uint16
+		wantDL byte
+		wantDH byte
 	}{
-		{0, 0, 0, nil},
-		{1, 1, 0, nil},
-		{0x1234, 0x34, 0x12, nil},
-		{0xFFFF, 0xFF, 0xFF, nil},
-		{-1, 0, 0, common.ErrLengthOutOfRange},
-		{0x10000, 0, 0, common.ErrLengthOutOfRange},
+		{0, 0, 0},
+		{1, 1, 0},
+		{0x1234, 0x34, 0x12},
+		{0xFFFF, 0xFF, 0xFF},
 	}
 	for _, tt := range tests {
-		dL, dH, err := common.LengthLowHigh(tt.length)
-		if !errors.Is(err, tt.wantErr) {
-			t.Errorf("LengthLowHigh(%d) error = %v; want %v", tt.length, err, tt.wantErr)
+		dL, dH := common.LengthLowHigh(tt.length)
+
+		if dL != tt.wantDL || dH != tt.wantDH {
+			t.Errorf("LengthLowHigh(%d) = (%#x,%#x); want (%#x,%#x)", tt.length, dL, dH, tt.wantDL, tt.wantDH)
 		}
-		if err == nil {
-			if dL != tt.wantDL || dH != tt.wantDH {
-				t.Errorf("LengthLowHigh(%d) = (%#x,%#x); want (%#x,%#x)", tt.length, dL, dH, tt.wantDL, tt.wantDH)
-			}
-		}
+
 	}
 }

--- a/escpos/escpos_integration_test.go
+++ b/escpos/escpos_integration_test.go
@@ -133,7 +133,7 @@ func TestIntegration_CompleteReceiptFlow(t *testing.T) {
 func TestIntegration_CustomCapabilities(t *testing.T) {
 	// Create a custom Commands with specific implementations
 	customCmd := &escpos.Protocol{
-		Print:     &print.Commands{Page: &print.PagePrint{}},
+		Print:     &print.Commands{},
 		LineSpace: &linespacing.Commands{},
 	}
 

--- a/escpos/escpos_test.go
+++ b/escpos/escpos_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/adcondev/pos-printer/escpos"
 	"github.com/adcondev/pos-printer/escpos/common"
-	"github.com/adcondev/pos-printer/escpos/linespacing"
 	"github.com/adcondev/pos-printer/escpos/print"
 )
 
@@ -82,27 +81,6 @@ func TestNewEscposProtocol_Initialization(t *testing.T) {
 		t.Fatal("NewEscposCommands() LineSpace capability should not be nil")
 	}
 
-	// Verify Print has correct type and Page capability
-	pc, ok := cmd.Print.(*print.Commands)
-	if !ok {
-		t.Fatal("NewEscposCommands() Print should be of type *PrintCommands")
-	}
-
-	if pc.Page == nil {
-		t.Fatal("NewEscposCommands() PrintCommands.Page should not be nil")
-	}
-
-	// Verify Page has correct type
-	_, ok = pc.Page.(*print.PagePrint)
-	if !ok {
-		t.Error("NewEscposCommands() Page should be of type *PagePrint")
-	}
-
-	// Verify LineSpace has correct type
-	_, ok = cmd.LineSpace.(*linespacing.Commands)
-	if !ok {
-		t.Error("NewEscposCommands() LineSpace should be of type *LineSpacingCommands")
-	}
 }
 
 func TestCommands_Integration_PrintWithLineSpacing(t *testing.T) {

--- a/escpos/graphics.go
+++ b/escpos/graphics.go
@@ -97,14 +97,29 @@ func (c *Protocol) PrintRasterBitImage(img *imaging.PrintImage, density Density)
 	cmd := []byte{common.GS, 'v', '0', mode}
 
 	// Agregar dimensiones
-	wL, wH, err := common.LengthLowHigh(escImg.GetWidthBytes())
-	if err != nil {
-		return nil, err
+	var widthBytes uint16
+	switch {
+	case escImg.GetWidthBytes() > 0xFFFF:
+		widthBytes = 0xFFFF
+	case escImg.GetWidthBytes() < 0x0:
+		widthBytes = 0x0
+	default:
+		// Secure, it has been validated
+		widthBytes = uint16(escImg.GetWidthBytes()) // nolint:gosec
 	}
-	hL, hH, err := common.LengthLowHigh(escImg.GetHeight())
-	if err != nil {
-		return nil, err
+	wL, wH := common.LengthLowHigh(widthBytes)
+
+	var heightBytes uint16
+	switch {
+	case escImg.GetHeight() > 0xFFFF:
+		heightBytes = 0xFFFF
+	case escImg.GetHeight() < 0:
+		heightBytes = 0
+	default:
+		// Secure, it has been validated
+		heightBytes = uint16(escImg.GetHeight()) // nolint:gosec
 	}
+	hL, hH := common.LengthLowHigh(heightBytes)
 
 	cmd = append(cmd, wL, wH) // Ancho en bytes
 	cmd = append(cmd, hL, hH) // Alto en píxeles

--- a/escpos/print/page_print.go
+++ b/escpos/print/page_print.go
@@ -55,30 +55,8 @@ var (
 )
 
 // ============================================================================
-// Interface Definitions
-// ============================================================================
-
-var _ PageModeCapability = (*PagePrint)(nil)
-
-// PageModeCapability defines the interface for page mode capabilities
-type PageModeCapability interface {
-	PrintAndReverseFeed(units byte) ([]byte, error)
-	PrintAndReverseFeedLines(lines byte) ([]byte, error)
-	CancelData() []byte
-	PrintDataInPageMode() []byte
-	PrintAndFeedLines(lines byte) []byte
-}
-
-// ============================================================================
 // Main Implementation
 // ============================================================================
-
-// PagePrint groups page mode printing commands
-type PagePrint struct{}
-
-func NewPagePrint() *PagePrint {
-	return &PagePrint{}
-}
 
 // PrintDataInPageMode prints the data in the print buffer collectively when
 // the printer is in Page mode.
@@ -109,7 +87,7 @@ func NewPagePrint() *PagePrint {
 // Byte sequence:
 //
 //	ESC FF -> 0x1B, 0x0C
-func (pp *PagePrint) PrintDataInPageMode() []byte {
+func (c *Commands) PrintDataInPageMode() []byte {
 	return []byte{common.ESC, FF}
 }
 
@@ -159,7 +137,7 @@ func (pp *PagePrint) PrintDataInPageMode() []byte {
 // Byte sequence:
 //
 //	ESC K input -> 0x1B, 0x4B, input
-func (pp *PagePrint) PrintAndReverseFeed(n byte) ([]byte, error) {
+func (c *Commands) PrintAndReverseFeed(n byte) ([]byte, error) {
 	if n > MaxReverseMotionUnits {
 		return nil, ErrPrintReverseFeed
 	}
@@ -207,7 +185,7 @@ func (pp *PagePrint) PrintAndReverseFeed(n byte) ([]byte, error) {
 // Byte sequence:
 //
 //	ESC e input -> 0x1B, 0x65, input
-func (pp *PagePrint) PrintAndReverseFeedLines(n byte) ([]byte, error) {
+func (c *Commands) PrintAndReverseFeedLines(n byte) ([]byte, error) {
 	if n > MaxReverseFeedLines {
 		return nil, ErrPrintReverseFeedLines
 	}
@@ -251,10 +229,10 @@ func (pp *PagePrint) PrintAndReverseFeedLines(n byte) ([]byte, error) {
 // Byte sequence:
 //
 //	ESC d input -> 0x1B, 0x64, input
-func (pp *PagePrint) PrintAndFeedLines(n byte) []byte {
+func (c *Commands) PrintAndFeedLines(n byte) []byte {
 	return []byte{common.ESC, 'd', n}
 }
 
-func (pp *PagePrint) CancelData() []byte {
+func (c *Commands) CancelData() []byte {
 	return []byte{CAN}
 }

--- a/escpos/print/print.go
+++ b/escpos/print/print.go
@@ -12,115 +12,16 @@ import (
 const (
 	// LF prints the data in the print buffer and feeds one line,
 	// based on the current line spacing.
-	//
-	// Format:
-	//   ASCII: LF
-	//   Hex:   0x0A
-	//   Decimal: 10
-	//
-	// Description:
-	//   Prints the data in the print buffer and feeds one line, according to the
-	//   currently selected line spacing.
-	//
-	// Notes:
-	//   - The amount of paper fed per line is based on the value set using the
-	//     line spacing command (ESC 2 or ESC 3).
-	//   - After printing, the print position is moved to the left side of the
-	//     printable area and the printer enters the "Beginning of the line"
-	//     status.
-	//   - When this command is processed in Page mode, only the print position
-	//     moves and the printer does not perform actual printing.
-	//
-	// Value is the single-byte LF (line feed) control code.
 	LF byte = 0x0A
 	// CR executes a carriage-return operation and (depending
 	// on the printer type and auto-line-feed setting) may print and cause a line feed.
-	//
-	// Format:
-	//   ASCII: CR
-	//   Hex:   0x0D
-	//   Decimal: 13
-	//
-	// Description:
-	//   Executes one of the following operations depending on the print head and
-	//   auto-line-feed state:
-	//
-	//   - Horizontal-alignment heads (Line thermal head or Shuttle head):
-	//     * When auto line feed is enabled: Executes printing and one line feed
-	//       as if LF was issued.
-	//     * When auto line feed is disabled: The command is ignored.
-	//
-	//   - Vertical-alignment heads (Serial dot head):
-	//     * Executes printing and one line feed as if LF was issued.
-	//
-	//   - In Standard mode:
-	//     * Prints the data in the print buffer (when applicable) and moves the
-	//       print position to the beginning of the print line (left side of the
-	//       printable area).
-	//   - In Page mode:
-	//     * Moves the print position to the beginning of the print line. When
-	//       processed in Page mode, the printer does not perform actual printing.
-	//
-	// Notes:
-	//   - With a serial interface, this command behaves as if auto line feed is
-	//     disabled.
-	//   - Enabling or disabling auto line feed may be controlled by a DIP
-	//     switch or the memory switch. The memory switch can be changed via
-	//     GS ( E <Function 3>.
-	//   - After printing, the print position is moved to the left side of the
-	//     printable area and the printer enters the "Beginning of the line"
-	//     status (when printing occurs).
-	//
-	// Value:
-	//   The CR control code is a single byte 0x0D (decimal 13).
 	CR byte = 0x0D
-	// FF (Form Feed) — behaviour in Standard mode and Page mode.
-	//
-	// Format:
-	//   ASCII: FF
-	//   Hex:   0x0C
-	//   Decimal: 12
-	//
-	// Summary:
-	//   FF is the single-byte Form Feed control code. Its behaviour depends on
-	//   the current printer mode.
-	//
-	// FF (in Page mode)
-	// Name:
-	//   Print and return to Standard mode (in Page mode)
-	//
-	// Description:
-	//   In Page mode, FF prints all the data in the print buffer collectively
+	// FF (in Page mode) - In Page mode, FF prints all the data in the print buffer collectively
 	//   and switches the printer from Page mode to Standard mode.
 	//
-	// Notes:
-	//   - This command is enabled only in Page mode. Page mode can be selected
-	//     by ESC L.
-	//   - The data in the print area is deleted after being printed.
-	//   - This command resets the values set by ESC W to their defaults.
-	//   - The value set by ESC T is maintained.
-	//   - After printing, the printer returns to Standard mode, the print
-	//     position moves to the left side of the printable area, and the printer
-	//     enters the "Beginning of the line" status.
-	//
-	// FF (in Standard mode)
-	// Name:
-	//   End job (in Standard mode)
-	//
-	// Description:
-	//   In Standard mode, FF indicates that "Printing is completed" for the
+	// FF (in Standard mode) - In Standard mode, FF indicates that "Printing is completed" for the
 	//   current job. This signals that a series of printing actions has been
 	//   completed and subsequent data will be printed as a new, separate job.
-	//
-	// Notes:
-	//   - This command is enabled only in Standard mode. Standard mode can be
-	//     selected by ESC S.
-	//   - When the cutting position has been reserved by GS V <Function C> or
-	//     GS ( V <Function 51>, issuing FF will feed the paper to the cutting
-	//     position and perform the cut.
-	//
-	// Value:
-	//   The FF control code is a single byte 0x0C (decimal 12).
 	FF byte = 0x0C
 )
 
@@ -162,18 +63,14 @@ func Formatting(data []byte) []byte {
 }
 
 // Commands groups printing-related commands
-type Commands struct {
-	Page PageModeCapability
-}
+type Commands struct{}
 
 func NewCommands() *Commands {
-	return &Commands{
-		Page: NewPagePrint(),
-	}
+	return &Commands{}
 }
 
 // Text formats and sends a string for printing
-func (pc *Commands) Text(n string) ([]byte, error) {
+func (c *Commands) Text(n string) ([]byte, error) {
 	if err := common.IsBufLenOk([]byte(n)); err != nil {
 		return nil, err
 	}
@@ -224,7 +121,7 @@ func (pc *Commands) Text(n string) ([]byte, error) {
 // Byte sequence:
 //
 //	ESC J input -> 0x1B, 0x4A, input
-func (pc *Commands) PrintAndFeedPaper(n byte) []byte {
+func (c *Commands) PrintAndFeedPaper(n byte) []byte {
 	return []byte{common.ESC, 'J', n}
 }
 
@@ -284,7 +181,7 @@ func (pc *Commands) PrintAndFeedPaper(n byte) []byte {
 // Value:
 //
 //	The FF control code is a single byte 0x0C (decimal 12).
-func (pc *Commands) FormFeed() []byte {
+func (c *Commands) FormFeed() []byte {
 	return []byte{FF}
 }
 
@@ -327,7 +224,7 @@ func (pc *Commands) FormFeed() []byte {
 //     printer does not perform actual printing.
 //
 // Value is the single-byte CR (carriage return) control code.
-func (pc *Commands) PrintAndCarriageReturn() []byte {
+func (c *Commands) PrintAndCarriageReturn() []byte {
 	return []byte{CR}
 }
 
@@ -355,6 +252,6 @@ func (pc *Commands) PrintAndCarriageReturn() []byte {
 //     moves and the printer does not perform actual printing.
 //
 // Value is the single-byte LF (line feed) control code.
-func (pc *Commands) PrintAndLineFeed() []byte {
+func (c *Commands) PrintAndLineFeed() []byte {
 	return []byte{LF}
 }

--- a/escpos/print/print_integration_test.go
+++ b/escpos/print/print_integration_test.go
@@ -65,10 +65,10 @@ func TestIntegration_PageMode_Workflow(t *testing.T) {
 		buffer = append(buffer, text...)
 
 		// Print page
-		buffer = append(buffer, cmd.Page.PrintDataInPageMode()...)
+		buffer = append(buffer, cmd.PrintDataInPageMode()...)
 
 		// Cancel if needed
-		buffer = append(buffer, cmd.Page.CancelData()...)
+		buffer = append(buffer, cmd.CancelData()...)
 
 		// Verify page mode commands
 		if !bytes.Contains(buffer, []byte{print.CAN}) {
@@ -88,13 +88,13 @@ func TestIntegration_Print_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("handles page mode errors", func(t *testing.T) {
-		_, err := cmd.Page.PrintAndReverseFeed(100) // Exceeds max
+		_, err := cmd.PrintAndReverseFeed(100) // Exceeds max
 		if !errors.Is(err, print.ErrPrintReverseFeed) {
 			t.Errorf("PrintAndReverseFeed(100) error = %v, want %v",
 				err, print.ErrPrintReverseFeed)
 		}
 
-		_, err = cmd.Page.PrintAndReverseFeedLines(10) // Exceeds max
+		_, err = cmd.PrintAndReverseFeedLines(10) // Exceeds max
 		if !errors.Is(err, print.ErrPrintReverseFeedLines) {
 			t.Errorf("PrintAndReverseFeedLines(10) error = %v, want %v",
 				err, print.ErrPrintReverseFeedLines)
@@ -137,22 +137,22 @@ func TestIntegration_Print_PageModeComplete(t *testing.T) {
 		commands = append(commands, text...)
 
 		// Reverse operations
-		reverse, _ := cmd.Page.PrintAndReverseFeed(10)
+		reverse, _ := cmd.PrintAndReverseFeed(10)
 		commands = append(commands, reverse...)
 
-		reverseLine, _ := cmd.Page.PrintAndReverseFeedLines(1)
+		reverseLine, _ := cmd.PrintAndReverseFeedLines(1)
 		commands = append(commands, reverseLine...)
 
 		// Forward feed
-		forward := cmd.Page.PrintAndFeedLines(5)
+		forward := cmd.PrintAndFeedLines(5)
 		commands = append(commands, forward...)
 
 		// Print page
-		printPage := cmd.Page.PrintDataInPageMode()
+		printPage := cmd.PrintDataInPageMode()
 		commands = append(commands, printPage...)
 
 		// Clear if needed
-		clean := cmd.Page.CancelData()
+		clean := cmd.CancelData()
 		commands = append(commands, clean...)
 
 		// Verify sequence integrity

--- a/escpos/print/print_test.go
+++ b/escpos/print/print_test.go
@@ -224,8 +224,8 @@ func TestCommands_PrintAndLineFeed(t *testing.T) {
 // PagePrint Tests
 // ============================================================================
 
-func TestPagePrint_PrintDataInPageMode(t *testing.T) {
-	pp := &print.PagePrint{}
+func TestCommands_PrintDataInPageMode(t *testing.T) {
+	pp := print.NewCommands()
 	got := pp.PrintDataInPageMode()
 	want := []byte{common.ESC, print.FF}
 
@@ -234,8 +234,8 @@ func TestPagePrint_PrintDataInPageMode(t *testing.T) {
 	}
 }
 
-func TestPagePrint_CancelData(t *testing.T) {
-	pp := &print.PagePrint{}
+func TestCommands_CancelData(t *testing.T) {
+	pp := print.NewCommands()
 	got := pp.CancelData()
 	want := []byte{print.CAN}
 
@@ -244,8 +244,8 @@ func TestPagePrint_CancelData(t *testing.T) {
 	}
 }
 
-func TestPagePrint_PrintAndReverseFeed(t *testing.T) {
-	pp := &print.PagePrint{}
+func TestCommands_PrintAndReverseFeed(t *testing.T) {
+	pp := print.NewCommands()
 
 	tests := []struct {
 		name    string
@@ -306,8 +306,8 @@ func TestPagePrint_PrintAndReverseFeed(t *testing.T) {
 	}
 }
 
-func TestPagePrint_PrintAndReverseFeedLines(t *testing.T) {
-	pp := &print.PagePrint{}
+func TestCommands_PrintAndReverseFeedLines(t *testing.T) {
+	pp := print.NewCommands()
 
 	tests := []struct {
 		name    string
@@ -369,7 +369,7 @@ func TestPagePrint_PrintAndReverseFeedLines(t *testing.T) {
 }
 
 func TestPagePrint_PrintAndFeedLines(t *testing.T) {
-	pp := &print.PagePrint{}
+	pp := print.NewCommands()
 
 	tests := []struct {
 		name    string

--- a/escpos/printposition/print_position.go
+++ b/escpos/printposition/print_position.go
@@ -1,0 +1,630 @@
+package printposition
+
+import (
+	"fmt"
+
+	"github.com/adcondev/pos-printer/escpos/common"
+)
+
+// ============================================================================
+// Constant and Var Definitions
+// ============================================================================
+
+// Control characters
+const (
+	// HT moves the print position to the next horizontal tab position.
+	HT byte = common.HT // 0x09
+)
+
+// Justification modes
+const (
+	JustifyLeft        byte = 0x00 // n = 0
+	JustifyCenter      byte = 0x01 // n = 1
+	JustifyRight       byte = 0x02 // n = 2
+	JustifyLeftASCII   byte = '0'  // n = 48
+	JustifyCenterASCII byte = '1'  // n = 49
+	JustifyRightASCII  byte = '2'  // n = 50
+)
+
+// Print direction modes (Page mode)
+const (
+	DirectionLeftToRight byte = 0x00 // n = 0 (upper left start)
+	DirectionBottomToTop byte = 0x01 // n = 1 (lower left start)
+	DirectionRightToLeft byte = 0x02 // n = 2 (lower right start)
+	DirectionTopToBottom byte = 0x03 // n = 3 (upper right start)
+
+	DirectionLeftToRightASCII byte = '0' // n = 48
+	DirectionBottomToTopASCII byte = '1' // n = 49
+	DirectionRightToLeftASCII byte = '2' // n = 50
+	DirectionTopToBottomASCII byte = '3' // n = 51
+)
+
+// Beginning of line operations
+const (
+	BeginLineErase byte = 0x00 // n = 0 (erase buffer)
+	BeginLinePrint byte = 0x01 // n = 1 (print buffer)
+
+	BeginLineEraseASCII byte = '0' // n = 48
+	BeginLinePrintASCII byte = '1' // n = 49
+)
+
+// Tab position limits
+const (
+	MaxTabPositions = 32
+	MaxTabValue     = 255
+)
+
+// ============================================================================
+// Error Definitions
+// ============================================================================
+
+var (
+	ErrInvalidJustification  = fmt.Errorf("invalid justification mode (try 0-2 or '0'..'2')")
+	ErrInvalidPrintDirection = fmt.Errorf("invalid print direction (try 0-3 or '0'..'3')")
+	ErrInvalidBeginLineMode  = fmt.Errorf("invalid begin line mode (try 0-1 or '0'..'1')")
+	ErrTooManyTabPositions   = fmt.Errorf("too many tab positions (max %d)", MaxTabPositions)
+	ErrInvalidTabPosition    = fmt.Errorf("invalid tab position (must be 1-255 in ascending order)")
+	ErrInvalidPrintAreaSize  = fmt.Errorf("invalid print area size (width and height must be >= 1)")
+	ErrInvalidPosition       = fmt.Errorf("invalid position value")
+)
+
+// ============================================================================
+// Interface Definitions
+// ============================================================================
+
+// Interface compliance check
+var _ Capability = (*Commands)(nil)
+
+// Capability defines the interface for print position commands
+type Capability interface {
+	// Basic positioning
+	SetAbsolutePrintPosition(position uint16) []byte
+	SetRelativePrintPosition(distance int16) []byte
+	HorizontalTab() []byte
+	SetHorizontalTabPositions(positions []byte) ([]byte, error)
+
+	// Justification
+	SelectJustification(mode byte) ([]byte, error)
+
+	// Margins and print area
+	SetLeftMargin(margin uint16) []byte
+	SetPrintAreaWidth(width uint16) []byte
+	SetPrintPositionBeginningLine(mode byte) ([]byte, error)
+
+	// Page mode specific
+	SelectPrintDirectionPageMode(direction byte) ([]byte, error)
+	SetPrintAreaPageMode(x, y, width, height uint16) []byte
+	SetAbsoluteVerticalPrintPosition(position uint16) []byte
+	SetRelativeVerticalPrintPosition(distance int16) []byte
+}
+
+// ============================================================================
+// Main Implementation
+// ============================================================================
+
+// Commands implements the Capability interface for print position commands
+type Commands struct{}
+
+func NewCommands() *Commands {
+	return &Commands{}
+}
+
+// HorizontalTab moves the print position to the next horizontal tab position.
+//
+// Format:
+//
+//	ASCII: HT
+//	Hex:   0x09
+//	Decimal: 9
+//
+// Description:
+//
+//	Moves the print position to the next horizontal tab position.
+//
+// Notes:
+//   - Ignored unless the next horizontal tab position has been set (ESC D).
+//   - If the next tab position exceeds the print area, print position is set to [Print area width + 1].
+//   - If processed when at [Print area width + 1], the printer executes print-buffer-full for the current line and performs horizontal tab processing from the beginning of the next line.
+//     In Page mode, printing is not executed but the print position is moved.
+//   - The printer will not move to the beginning of the line by executing this command.
+//   - When underline mode is on, the underline is not printed under the tab space skipped by this command.
+//
+// Byte sequence:
+//
+//	HT -> 0x09
+func (c *Commands) HorizontalTab() []byte {
+	return []byte{HT}
+}
+
+// SetAbsolutePrintPosition sets the absolute print position.
+//
+// Format:
+//
+//	ASCII: ESC $ nL nH
+//	Hex:   0x1B 0x24 nL nH
+//	Decimal: 27 36 nL nH
+//
+// Range:
+//
+//	(nL + nH × 256) = 0 – 65535
+//
+// Default:
+//
+//	None
+//
+// Description:
+//
+//	Moves the print position to (nL + nH × 256) × (horizontal or vertical motion unit)
+//	from the left edge of the print area.
+//
+// Notes:
+//   - The printer ignores any setting that exceeds the print area.
+//   - In Standard mode the horizontal motion unit is used.
+//   - In Page mode the horizontal or vertical motion unit is used depending on
+//     the print direction set by ESC T.
+//   - If the starting position is set to upper-left or lower-right using ESC T,
+//     the horizontal motion unit is used; for upper-right or lower-left the vertical
+//     motion unit is used.
+//   - If the motion unit changes after this command, the print position is not changed.
+//   - The printer will not move to the beginning of the line by executing this command.
+//   - When underline mode is on, the underline is not printed under the space skipped
+//     by this command.
+//
+// Byte sequence:
+//
+//	ESC $ nL nH -> 0x1B, 0x24, nL, nH
+func (c *Commands) SetAbsolutePrintPosition(position uint16) []byte {
+	nL := byte(position & 0xFF)
+	nH := byte((position >> 8) & 0xFF)
+	return []byte{common.ESC, '$', nL, nH}
+}
+
+// SetHorizontalTabPositions sets horizontal tab positions.
+//
+// Format:
+//
+//	ASCII: ESC D n1 ... nk NUL
+//	Hex:   0x1B 0x44 n1 ... nk 0x00
+//	Decimal: 27 68 n1 ... nk 0
+//
+// Range:
+//
+//	n = 1–255
+//	k = 0–32
+//
+// Default:
+//
+//	n = 8, 16, 24, 32, ..., 232, 240, 248 (every eight characters for the default font set)
+//
+// Description:
+//
+//	Sets horizontal tab positions. Each transmitted n value specifies the number
+//	of character widths from the line start to the tab stop. Transmit the tab
+//	stops in ascending order and terminate the list with NUL (0x00). Transmitting
+//	ESC D NUL clears all horizontal tab positions.
+//
+// Notes:
+//   - The tab position is stored as [character width × n], where character width
+//     includes right-side character spacing. Double-width characters count as
+//     twice the width.
+//   - Character width and font/spacing/enlargement should be set before sending this command.
+//   - A maximum of 32 tab positions can be set; data beyond 32 is treated as normal data.
+//   - If a transmitted n is less than or equal to the previous value, tab-setting
+//     is finished and subsequent bytes are processed as normal data.
+//   - Tab settings are preserved until ESC @ (initialize), printer reset, or power-off.
+//   - Changing the left margin will shift stored tab positions accordingly.
+//   - Horizontal tab positions that exceed the print area are allowed; they become
+//     effective or not depending on the current print area width.
+//
+// Byte sequence:
+//
+//	ESC D n1 ... nk NUL -> 0x1B, 0x44, n1, ..., nk, 0x00
+func (c *Commands) SetHorizontalTabPositions(positions []byte) ([]byte, error) {
+	// Check maximum number of positions
+	if len(positions) > MaxTabPositions {
+		return nil, ErrTooManyTabPositions
+	}
+
+	// Validate positions are in ascending order and within range
+	prevPos := byte(0)
+	for i, pos := range positions {
+		if pos == 0 || pos > MaxTabValue {
+			return nil, fmt.Errorf("%w: position %d at index %d", ErrInvalidTabPosition, pos, i)
+		}
+		if pos <= prevPos {
+			return nil, fmt.Errorf("%w: position %d at index %d must be greater than %d", ErrInvalidTabPosition, pos, i, prevPos)
+		}
+		prevPos = pos
+	}
+
+	// Build command
+	cmd := []byte{common.ESC, 'D'}
+	cmd = append(cmd, positions...)
+	cmd = append(cmd, common.NUL)
+	return cmd, nil
+}
+
+// SelectPrintDirectionPageMode selects the print direction and starting position in Page mode.
+//
+// Format:
+//
+//	ASCII: ESC T n
+//	Hex:   0x1B 0x54 n
+//	Decimal: 27 84 n
+//
+// Range:
+//
+//	n = 0–3, 48–51
+//
+// Default:
+//
+//	n = 0 (Left to right, starting position: upper left)
+//
+// Description:
+//
+//	In Page mode, selects print direction and starting position as follows:
+//	  n = 0 or 48 -> Print direction: left to right;  Starting position: upper left
+//	  n = 1 or 49 -> Print direction: bottom to top;  Starting position: lower left
+//	  n = 2 or 50 -> Print direction: right to left;  Starting position: lower right
+//	  n = 3 or 51 -> Print direction: top to bottom;  Starting position: upper right
+//
+// Notes:
+//   - Effective only in Page mode; has no effect in Standard mode.
+//   - The meaning of horizontal/vertical motion units for other commands depends on the selected starting position (see command reference).
+//   - Settings persist until ESC @ (initialize), printer reset, or power-off.
+//
+// Byte sequence:
+//
+//	ESC T n -> 0x1B, 0x54, n
+func (c *Commands) SelectPrintDirectionPageMode(direction byte) ([]byte, error) {
+	// Validate allowed values
+	switch direction {
+	case 0, 1, 2, 3, '0', '1', '2', '3':
+		// Valid values
+	default:
+		return nil, ErrInvalidPrintDirection
+	}
+	return []byte{common.ESC, 'T', direction}, nil
+}
+
+// SetPrintAreaPageMode sets the print area and logical origin in Page mode.
+//
+// Format:
+//
+//	ASCII: ESC W xL xH yL yH dxL dxH dyL dyH
+//	Hex:   0x1B 0x57 xL xH yL yH dxL dxH dyL dyH
+//	Decimal: 27 87 xL xH yL yH dxL dxH dyL dyH
+//
+// Description:
+//
+//	In Page mode, defines the logical origin (horizontal and vertical) and the
+//	print area size. The transmitted parameters are interpreted as 16-bit
+//	little-endian values: value = (low + high * 256), each measured in the
+//	horizontal or vertical motion unit as appropriate.
+//
+//	  Horizontal logical origin = (xL + xH*256) × (horizontal motion unit)
+//	  Vertical logical origin   = (yL + yH*256) × (vertical motion unit)
+//	  Print area width          = (dxL + dxH*256) × (horizontal motion unit)
+//	  Print area height         = (dyL + dyH*256) × (vertical motion unit)
+//
+// Notes:
+//   - This command only has effect in Page mode (ESC L) and is ignored in Standard mode.
+//   - Both print area width and height must be at least 1 (cannot be zero).
+//   - Logical origins must lie within the printable area.
+//   - If origin + size exceeds the printable area, the size is reduced to fit.
+//   - Values are fixed even if motion units change later.
+//   - Settings persist until FF (in Page mode), ESC @ (initialize), reset, or power-off.
+//   - The absolute origin is the upper-left of the printable area.
+//   - For printers supporting GS ( P <Function 48>, the maximum and origin align with that printable area setting.
+//
+// Byte sequence:
+//
+//	ESC W xL xH yL yH dxL dxH dyL dyH -> 0x1B, 0x57, xL, xH, yL, yH, dxL, dxH, dyL, dyH
+func (c *Commands) SetPrintAreaPageMode(x, y, width, height uint16) []byte {
+	xL := byte(x & 0xFF)
+	xH := byte((x >> 8) & 0xFF)
+	yL := byte(y & 0xFF)
+	yH := byte((y >> 8) & 0xFF)
+	dxL := byte(width & 0xFF)
+	dxH := byte((width >> 8) & 0xFF)
+	dyL := byte(height & 0xFF)
+	dyH := byte((height >> 8) & 0xFF)
+
+	return []byte{common.ESC, 'W', xL, xH, yL, yH, dxL, dxH, dyL, dyH}
+}
+
+// SetRelativePrintPosition moves the print position relative to the current position.
+//
+// Format:
+//
+//	ASCII: ESC \ nL nH
+//	Hex:   0x1B 0x5C nL nH
+//	Decimal: 27 92 nL nH
+//
+// Range:
+//
+//	(nL + nH × 256) = -32768 – 32767 (signed 16-bit value; low + high*256 interpreted as int16)
+//
+// Default:
+//
+//	None
+//
+// Description:
+//
+//	Moves the print position by (nL + nH × 256) × (horizontal or vertical motion unit)
+//	from the current position. Positive moves to the right; negative moves to the left.
+//
+// Notes:
+//   - The printer ignores any setting that exceeds the print area.
+//   - In Standard mode the horizontal motion unit is used.
+//   - In Page mode the horizontal or vertical motion unit is used depending on the print direction set by ESC T.
+//   - If the starting position is upper-left or lower-right (ESC T), the horizontal motion unit is used.
+//     If the starting position is upper-right or lower-left, the vertical motion unit is used.
+//   - Changing motion units after this command does not change the already-set print position.
+//   - Underline mode does not print under the space skipped by this command.
+//   - In JIS code, '\' corresponds to '¥'.
+//
+// Byte sequence:
+//
+//	ESC \ nL nH -> 0x1B, 0x5C, nL, nH
+func (c *Commands) SetRelativePrintPosition(distance int16) []byte {
+	// Convert signed int16 to unsigned bytes (little-endian)
+	// intentional: preserve int16 two's-complement bit pattern for ESC \ command
+	value := uint16(distance) // nolint:gosec
+	nL := byte(value & 0xFF)
+	nH := byte((value >> 8) & 0xFF)
+	return []byte{common.ESC, '\\', nL, nH}
+}
+
+// SelectJustification selects text justification in Standard mode.
+//
+// Format:
+//
+//	ASCII: ESC a n
+//	Hex:   0x1B 0x61 n
+//	Decimal: 27 97 n
+//
+// Range:
+//
+//	n = 0–2, 48–50
+//
+// Default:
+//
+//	n = 0 (Left)
+//
+// Description:
+//
+//	In Standard mode, aligns all data in one line according to n:
+//	  0 or 48 -> Left justification
+//	  1 or 49 -> Centered
+//	  2 or 50 -> Right justification
+//
+// Notes:
+//   - Effective only in Standard mode and only when processed at the beginning of a line.
+//   - Has no effect in Page mode.
+//   - Justification is applied within the print area set by GS L and ESC W/GS W.
+//   - Affects characters, graphics, barcodes, 2D codes and space areas set by HT, ESC $, ESC \.
+//   - Setting persists until ESC @, reset, or power-off.
+//
+// Byte sequence:
+//
+//	ESC a n -> 0x1B, 0x61, n
+func (c *Commands) SelectJustification(mode byte) ([]byte, error) {
+	// Validate allowed values
+	switch mode {
+	case 0, 1, 2, '0', '1', '2':
+		// Valid values
+	default:
+		return nil, ErrInvalidJustification
+	}
+	return []byte{common.ESC, 'a', mode}, nil
+}
+
+// SetAbsoluteVerticalPrintPosition sets the absolute vertical print position in Page mode.
+//
+// Format:
+//
+//	ASCII: GS $ nL nH
+//	Hex:   0x1D 0x24 nL nH
+//	Decimal: 29 36 nL nH
+//
+// Range:
+//
+//	(nL + nH × 256) = 0 – 65535
+//
+// Default:
+//
+//	None
+//
+// Description:
+//
+//	In Page mode, moves the vertical print position to (nL + nH × 256) × (vertical or horizontal motion unit)
+//	from the starting position set by ESC T.
+//
+// Notes:
+//   - This command is enabled only in Page mode; it is ignored in Standard mode.
+//   - The printer ignores any setting that exceeds the print area set by ESC W.
+//   - The horizontal or vertical motion unit used depends on the print direction set by ESC T.
+//   - If the starting position is upper left or lower right, the vertical motion unit is used.
+//     If the starting position is upper right or lower left, the horizontal motion unit is used.
+//   - Changing motion units after this command does not change the already-set print position.
+//
+// Byte sequence:
+//
+//	GS $ nL nH -> 0x1D, 0x24, nL, nH
+func (c *Commands) SetAbsoluteVerticalPrintPosition(position uint16) []byte {
+	nL := byte(position & 0xFF)
+	nH := byte((position >> 8) & 0xFF)
+	return []byte{common.GS, '$', nL, nH}
+}
+
+// SetLeftMargin sets the left margin in Standard mode.
+//
+// Format:
+//
+//	ASCII: GS L nL nH
+//	Hex:   0x1D 0x4C nL nH
+//	Decimal: 29 76 nL nH
+//
+// Range:
+//
+//	(nL + nH × 256) = 0 – 65535
+//
+// Default:
+//
+//	(nL + nH × 256) = 0
+//
+// Description:
+//
+//	In Standard mode, sets the left margin to (nL + nH × 256) × (horizontal motion unit)
+//	from the left edge of the printable area.
+//
+// Notes:
+//   - Effective in Standard mode only when processed at the beginning of the line.
+//   - Has no effect while in Page mode; if issued in Page mode the value is stored
+//     and enabled when returning to Standard mode.
+//   - If the setting exceeds the printable area, it is clamped to the printable-area maximum.
+//   - If this command and GS W would set the print area width to less than one character,
+//     the print area width is extended to accommodate one character.
+//   - Uses the horizontal motion unit; changes to the motion unit after setting do not change the margin.
+//   - Setting persists until ESC @ (initialize), printer reset, or power-off.
+//   - The left margin is measured from the left edge of the printable area; changing the left margin moves that edge.
+//
+// Byte sequence:
+//
+//	GS L nL nH -> 0x1D, 0x4C, nL, nH
+func (c *Commands) SetLeftMargin(margin uint16) []byte {
+	nL := byte(margin & 0xFF)
+	nH := byte((margin >> 8) & 0xFF)
+	return []byte{common.GS, 'L', nL, nH}
+}
+
+// SetPrintPositionBeginningLine moves the print position to the beginning of the print line.
+//
+// Format:
+//
+//	ASCII: GS T n
+//	Hex:   0x1D 0x54 n
+//	Decimal: 29 84 n
+//
+// Range:
+//
+//	n = 0, 1, 48, 49
+//
+// Default:
+//
+//	None
+//
+// Description:
+//
+//	In Standard mode, moves the print position to the beginning (left side) of the printable area
+//	after performing the operation specified by n. n controls how the print buffer is processed:
+//
+//	  n = 0 or 48 -> Erase the data in the print buffer, then move the print position.
+//	  n = 1 or 49 -> Print the data in the print buffer, then move the print position (starts a new line based on line spacing).
+//
+// Notes:
+//   - Effective only in Standard mode; ignored in Page mode.
+//   - Ignored if the print position is already at the beginning of the line.
+//   - If print position is not at the beginning of the line and n = 1 or 49, this behaves the same as LF.
+//   - Erase (n = 0 or 48) cancels the current print-buffered data but preserves other settings and buffer contents.
+//   - After execution the printer is in the "Beginning of the line" status.
+//   - Use this command immediately before other commands that require beginning-of-line to ensure they execute.
+//
+// Byte sequence:
+//
+//	GS T n -> 0x1D, 0x54, n
+func (c *Commands) SetPrintPositionBeginningLine(mode byte) ([]byte, error) {
+	// Validate allowed values
+	switch mode {
+	case 0, 1, '0', '1':
+		// Valid values
+	default:
+		return nil, ErrInvalidBeginLineMode
+	}
+	return []byte{common.GS, 'T', mode}, nil
+}
+
+// SetPrintAreaWidth sets the print area width in Standard mode.
+//
+// Format:
+//
+//	ASCII: GS W nL nH
+//	Hex:   0x1D 0x57 nL nH
+//	Decimal: 29 87 nL nH
+//
+// Range:
+//
+//	(nL + nH × 256) = 0 – 65535
+//
+// Default:
+//
+//	Entire printable area (model-dependent; see printer specs)
+//
+// Description:
+//
+//	In Standard mode, sets the print area width to (nL + nH × 256) × (horizontal motion unit).
+//
+// Notes:
+//   - This command is effective in Standard mode only when processed at the beginning of a line.
+//   - Has no effect in Page mode; if issued in Page mode the value is stored and enabled when returning to Standard mode.
+//   - If [left margin + print area width] exceeds the printable area, the print area width is clamped to [printable area - left margin].
+//   - If this command together with GS L would set the print area width to less than one character, the width is extended to accommodate one character.
+//   - Uses the horizontal motion unit. Changing the motion unit after setting does not change the stored width.
+//   - Setting persists until ESC @, printer reset, or power-off.
+//
+// Model example defaults (n = nL + nH*256):
+//
+//	80 mm paper -> n = 576
+//	58 mm paper -> n = 420
+//
+// Byte sequence:
+//
+//	GS W nL nH -> 0x1D, 0x57, nL, nH
+func (c *Commands) SetPrintAreaWidth(width uint16) []byte {
+	nL := byte(width & 0xFF)
+	nH := byte((width >> 8) & 0xFF)
+	return []byte{common.GS, 'W', nL, nH}
+}
+
+// SetRelativeVerticalPrintPosition moves the vertical print position relative to the current position in Page mode.
+//
+// Format:
+//
+//	ASCII: GS \ nL nH
+//	Hex:   0x1D 0x5C nL nH
+//	Decimal: 29 92 nL nH
+//
+// Range:
+//
+//	(nL + nH × 256) = -32768 – 32767  (signed 16-bit; low + high*256 interpreted as int16)
+//
+// Default:
+//
+//	None
+//
+// Description:
+//
+//	In Page mode, moves the vertical print position by (nL + nH × 256) × (vertical or horizontal motion unit)
+//	from the current position. A positive value moves downward; a negative value moves upward.
+//
+// Notes:
+//   - This command is enabled only in Page mode; it is ignored in Standard mode.
+//   - The printer ignores any setting that exceeds the print area set by ESC W.
+//   - The horizontal or vertical motion unit used depends on the print direction set by ESC T.
+//   - If starting position is upper-left or lower-right (ESC T), the vertical motion unit is used.
+//   - If starting position is upper-right or lower-left (ESC T), the horizontal motion unit is used.
+//   - Changes to the motion units after executing this command do not affect the already-set print position.
+//   - In JIS code, '\' corresponds to '¥'.
+//
+// Byte sequence:
+//
+//	GS \ nL nH -> 0x1D, 0x5C, nL, nH
+func (c *Commands) SetRelativeVerticalPrintPosition(distance int16) []byte {
+	// Convert signed int16 to unsigned bytes (little-endian)
+	// intentional: preserve int16 two's-complement bit pattern for ESC \ command
+	value := uint16(distance) // nolint:gosec
+	nL := byte(value & 0xFF)
+	nH := byte((value >> 8) & 0xFF)
+	return []byte{common.GS, '\\', nL, nH}
+}

--- a/escpos/qrcodes.go
+++ b/escpos/qrcodes.go
@@ -77,10 +77,8 @@ func (c *Protocol) SelectQRModel(model QRModel) ([]byte, error) {
 		return nil, fmt.Errorf("modelo de QR inválida(0-1): %d", model)
 	}
 
-	pL, pH, err := common.LengthLowHigh(4)
-	if err != nil {
-		return nil, fmt.Errorf("error al calcular longitud de parametros QR: %w", err)
-	}
+	pL, pH := common.LengthLowHigh(4)
+
 	cn, fn := byte('1'), byte('A')
 	n1 := modelMap[model]
 	n2 := byte(0) // Siempre 0, reservado
@@ -99,10 +97,8 @@ func (c *Protocol) SelectQRSize(moduleSize QRModuleSize) ([]byte, error) {
 		return nil, fmt.Errorf("tamaño de módulo QR inválido(1-16): %d", moduleSize)
 	}
 
-	pL, pH, err := common.LengthLowHigh(3)
-	if err != nil {
-		return nil, fmt.Errorf("error al calcular longitud de parametros QR: %w", err)
-	}
+	pL, pH := common.LengthLowHigh(3)
+
 	cn, fn := byte('1'), byte('C')
 	n := byte(moduleSize)
 
@@ -121,10 +117,8 @@ func (c *Protocol) SelectQRErrorCorrection(level QRErrorCorrection) ([]byte, err
 		return nil, fmt.Errorf("nivel de corrección de QR inválido(0-3): %d", level)
 	}
 
-	pL, pH, err := common.LengthLowHigh(3)
-	if err != nil {
-		return nil, fmt.Errorf("error al calcular longitud de parametros QR: %w", err)
-	}
+	pL, pH := common.LengthLowHigh(3)
+
 	cn, fn := byte('1'), byte('E')
 
 	cmd := make([]byte, 0, 8)
@@ -141,10 +135,9 @@ func (c *Protocol) SetQRData(data string) ([]byte, error) {
 		return nil, fmt.Errorf("longitud de datos de QR inválida (1-7089): %d", len(data))
 	}
 
-	pL, pH, err := common.LengthLowHigh(len(data) + 3)
-	if err != nil {
-		return nil, fmt.Errorf("error al calcular longitud de parametros QR: %w", err)
-	}
+	// Secure, it is validated before.
+	pL, pH := common.LengthLowHigh(uint16(len(data) + 3)) // nolint:gosec
+
 	cn, fn := byte('1'), byte('P')
 	m := byte('0') // Siempre 0, reservado
 
@@ -159,10 +152,8 @@ func (c *Protocol) SetQRData(data string) ([]byte, error) {
 // PrintQRData genera el comando para imprimir el código QR
 func (c *Protocol) PrintQRData() ([]byte, error) {
 	// Comando para imprimir QR
-	pL, pH, err := common.LengthLowHigh(3)
-	if err != nil {
-		return nil, fmt.Errorf("error al calcular longitud de parametros QR: %w", err)
-	}
+	pL, pH := common.LengthLowHigh(3)
+
 	cn, fn := byte('1'), byte('Q')
 	m := byte('0') // Siempre 0 para impresion estandard
 


### PR DESCRIPTION
## Descripción

<!-- ¿Qué cambia este PR? -->

## Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [ ] 📚 Solo documentación
- [ ] 🔧 Configuración
- [ ] ♻️ Refactoring
- [ ] 📦 Dependencias

## ¿Cómo se ha probado?

<!-- Marca lo que aplique -->

- [ ] Tests automáticos pasan
- [ ] Probado manualmente
- [ ] N/A (solo docs/config)

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Los tests pasan localmente
- [ ] He actualizado la documentación si era necesario

## Notas adicionales

<!-- Algo más que debamos saber? -->
This pull request refactors the ESCPOS printing command implementation to simplify the codebase and remove unnecessary abstractions, particularly around page mode printing. The changes unify printing commands under a single `Commands` struct, remove the `PageModeCapability` interface, and update related tests and usages. Additionally, the handling of length conversion for commands is streamlined for clarity and safety.

### Printing Command Refactor

* Removed the `PageModeCapability` interface and the `PagePrint` struct, merging all page mode printing methods directly into the `Commands` struct in `print.go` and `page_print.go`. This simplifies the API and removes unnecessary indirection. [[1]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL57-L82) [[2]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL112-R90) [[3]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL162-R140) [[4]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL210-R188) [[5]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL254-R236) [[6]](diffhunk://#diff-9c87836fcc387bdf1c16224869a32883ce5671ad97d489204e0a1b7a6275e63bL165-R73)
* Updated all printing-related methods (e.g., `PrintDataInPageMode`, `PrintAndReverseFeed`, etc.) to be methods of `Commands` instead of `PagePrint`, and removed the `Page` field from `Commands`. [[1]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL112-R90) [[2]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL162-R140) [[3]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL210-R188) [[4]](diffhunk://#diff-02aa0d1c94b6439d071f7f3df18b0b82314284d30b0e08473f902c44ca17161eL254-R236) [[5]](diffhunk://#diff-9c87836fcc387bdf1c16224869a32883ce5671ad97d489204e0a1b7a6275e63bL165-R73) [[6]](diffhunk://#diff-9c87836fcc387bdf1c16224869a32883ce5671ad97d489204e0a1b7a6275e63bL227-R124) [[7]](diffhunk://#diff-9c87836fcc387bdf1c16224869a32883ce5671ad97d489204e0a1b7a6275e63bL287-R184) [[8]](diffhunk://#diff-9c87836fcc387bdf1c16224869a32883ce5671ad97d489204e0a1b7a6275e63bL330-R227) [[9]](diffhunk://#diff-9c87836fcc387bdf1c16224869a32883ce5671ad97d489204e0a1b7a6275e63bL358-R255)

### Simplification and Safety Improvements

* Refactored the `LengthLowHigh` function to accept only `uint16` values, removing error handling for out-of-range values. Callers now clamp or convert values as needed before calling, improving safety and clarity. [[1]](diffhunk://#diff-0179ec55be018a5023976112c4686fa7e632adec324647ce38a3da46807fdd88L34-R37) [[2]](diffhunk://#diff-f7899b1f4efbf50915ec6f6eeb925e160393f9cfaed0a80f3ca8e2700acb1515L100-R122)
* Updated usages and tests for `LengthLowHigh` to match the new signature, removing test cases for negative and out-of-range values and simplifying test logic. [[1]](diffhunk://#diff-4665ae19c6ca331b60b495c29f57dc6b5bb1902ecf3447d40bb9444bb9c774baL33-R48) [[2]](diffhunk://#diff-f7899b1f4efbf50915ec6f6eeb925e160393f9cfaed0a80f3ca8e2700acb1515L100-R122)

### Test and Import Updates

* Removed references to `PageModeCapability` and `PagePrint` from tests and updated them to use the unified `Commands` struct. Cleaned up imports in related files. [[1]](diffhunk://#diff-ad544873c5adf25da126848be5c8813ec1825be403b37420e4155da69af0a657L10) [[2]](diffhunk://#diff-ad544873c5adf25da126848be5c8813ec1825be403b37420e4155da69af0a657L85-L105) [[3]](diffhunk://#diff-23fe54c433d6f55336448569e6278c59e22f987043f527afa5b3cea2412681a6L136-R136) [[4]](diffhunk://#diff-64eee50c9945d4f93a52d1f6f2a35fe92012c6f7c2d42fc460ea459fa77a73e4L15-L17)
* Enhanced the `FakeCapability` struct in test code to track additional state related to page mode printing, aligning it with the new unified command structure.

These changes result in a cleaner, more maintainable codebase with less duplication and clearer separation of responsibilities.