### PR TITLE
chore: verify linter suppression in SetPixel

### DIFF
--- a/pkg/graphics/bitmap.go
+++ b/pkg/graphics/bitmap.go
@@ -29,10 +29,9 @@ func (m *MonochromeBitmap) SetPixel(x, y int, black bool) {
 		return
 	}
 
-	// TODO: Make sure linter suppression is safe here
-
 	bytesPerRow := (m.Width + 7) / 8
 	byteIndex := y*bytesPerRow + x/8
+	// Safe: x is non-negative (checked above) so x%8 is [0,7], result is positive.
 	bitIndex := uint(7 - (x % 8)) //nolint:gosec
 
 	if black {
@@ -50,6 +49,7 @@ func (m *MonochromeBitmap) GetPixel(x, y int) bool {
 
 	bytesPerRow := (m.Width + 7) / 8
 	byteIndex := y*bytesPerRow + x/8
+	// Safe: x is non-negative (checked above) so x%8 is [0,7], result is positive.
 	bitIndex := uint(7 - (x % 8)) //nolint:gosec
 
 	return (m.data[byteIndex] & (1 << bitIndex)) != 0


### PR DESCRIPTION
Verified the safety of linter suppression in `pkg/graphics/bitmap.go`. Added comments explaining why `//nolint:gosec` is safe (due to bounds checking) and removed the corresponding TODO.

---
*PR created automatically by Jules for task [897706277274065471](https://jules.google.com/task/897706277274065471) started by @adcondev*