### PR TITLE
Refactor anonymous function to utility helper in print test

### DIFF
--- a/internal/testutils/byte_helpers.go
+++ b/internal/testutils/byte_helpers.go
@@ -31,6 +31,11 @@ func RepeatByte(length int, value byte) []byte {
 	return result
 }
 
+// GenerateString creates a string of specified length filled with value
+func GenerateString(length int, value byte) string {
+	return string(RepeatByte(length, value))
+}
+
 // ============================================================================
 // Command Builders
 // ============================================================================

--- a/pkg/commands/print/print_test.go
+++ b/pkg/commands/print/print_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/adcondev/poster/internal/testutils"
 	"github.com/adcondev/poster/pkg/commands/print"
 	"github.com/adcondev/poster/pkg/commands/shared"
 )
@@ -106,12 +107,8 @@ func TestCommands_Text(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "buffer overflow",
-			// FIXME: change anonymous func to utils helpers
-			text: func() string {
-				overflow := make([]byte, shared.MaxBuf+1)
-				return string(overflow)
-			}(),
+			name:    "buffer overflow",
+			text:    testutils.GenerateString(shared.MaxBuf+1, 0),
 			want:    nil,
 			wantErr: true,
 		},


### PR DESCRIPTION
Extracted the anonymous function used for generating buffer overflow strings in `pkg/commands/print/print_test.go` to a new helper function `GenerateString` in `internal/testutils/byte_helpers.go`. This improves code readability and reusability.

---
*PR created automatically by Jules for task [5966910367722800358](https://jules.google.com/task/5966910367722800358) started by @adcondev*