### PR TITLE
🔒 Fix DoS vulnerability in image resizing logic

### DIFF
--- a/pkg/graphics/processing.go
+++ b/pkg/graphics/processing.go
@@ -27,6 +27,10 @@ func DefaultResizeOptions(paperWidth int) *ResizeOptions {
 	}
 }
 
+// MaxImagePixelHeight is the maximum allowed height for a processed image to prevent
+// excessive memory allocation (DoS). 32000 pixels is approx 4 meters at 203 DPI.
+const MaxImagePixelHeight = 32000
+
 // ResizeImage scales an image to the target width while optionally preserving aspect ratio.
 func ResizeImage(img image.Image, opts *ResizeOptions) image.Image {
 	if img == nil {
@@ -56,6 +60,11 @@ func ResizeImage(img image.Image, opts *ResizeOptions) image.Image {
 	targetH := srcH
 	if opts.PreserveAspect && srcW > 0 {
 		targetH = (srcH * targetW) / srcW
+	}
+
+	// Safety check: Clamp height to prevent OOM
+	if targetH > MaxImagePixelHeight {
+		targetH = MaxImagePixelHeight
 	}
 
 	// Create destination image

--- a/pkg/graphics/processing_security_test.go
+++ b/pkg/graphics/processing_security_test.go
@@ -1,0 +1,49 @@
+package graphics_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/adcondev/poster/pkg/graphics"
+)
+
+// HugeImage is a mock image that reports huge dimensions but doesn't store data.
+type HugeImage struct {
+	W, H int
+}
+
+func (m *HugeImage) ColorModel() color.Model { return color.RGBAModel }
+func (m *HugeImage) Bounds() image.Rectangle { return image.Rect(0, 0, m.W, m.H) }
+func (m *HugeImage) At(x, y int) color.Color { return color.RGBA{0, 0, 0, 255} }
+
+func TestResizeImage_DoS_Vulnerability(t *testing.T) {
+	// Setup: srcW=10, srcH=1200, targetW=500.
+	// targetH would be (1200 * 500) / 10 = 60,000 without cap.
+	// With cap, it should be graphics.MaxImagePixelHeight (32000).
+
+	src := &HugeImage{W: 10, H: 1200}
+	opts := &graphics.ResizeOptions{
+		TargetWidth:    500,
+		MaxWidth:       576,
+		PreserveAspect: true,
+		Scaling:        graphics.BiLinear,
+	}
+
+	res := graphics.ResizeImage(src, opts)
+
+	if res == nil {
+		t.Fatal("ResizeImage returned nil")
+	}
+
+	bounds := res.Bounds()
+	t.Logf("Result bounds: %v", bounds)
+
+	if bounds.Dy() > graphics.MaxImagePixelHeight {
+		t.Errorf("Result height %d exceeds MaxImagePixelHeight %d", bounds.Dy(), graphics.MaxImagePixelHeight)
+	}
+
+	if bounds.Dy() != graphics.MaxImagePixelHeight {
+		t.Errorf("Expected result height to be capped at %d, got %d", graphics.MaxImagePixelHeight, bounds.Dy())
+	}
+}


### PR DESCRIPTION
This PR fixes a potential Denial of Service (DoS) vulnerability in `pkg/graphics/processing.go`.
The `ResizeImage` function previously calculated the target height based on the source image's aspect ratio without any upper bound. This allowed an attacker to provide an image with dimensions (e.g., extremely large height, small width) that would result in a massive `targetH`, causing `image.NewRGBA` to attempt allocating gigabytes of memory, leading to an OOM crash.

Changes:
- Added `const MaxImagePixelHeight = 32000` (approx 4 meters at 203 DPI) as a safety limit.
- Modified `ResizeImage` to clamp the calculated `targetH` to `MaxImagePixelHeight`.
- Added a regression test `pkg/graphics/processing_security_test.go` that attempts to trigger the excessive allocation and verifies that the height is correctly capped.


---
*PR created automatically by Jules for task [10886718502609095160](https://jules.google.com/task/10886718502609095160) started by @adcondev*