### PR TITLE
chore(graphics): remove ambiguous linter suppression TODO

### DIFF
--- a/pkg/graphics/bitmap.go
+++ b/pkg/graphics/bitmap.go
@@ -29,8 +29,6 @@ func (m *MonochromeBitmap) SetPixel(x, y int, black bool) {
 		return
 	}
 
-	// TODO: Make sure linter suppression is safe here
-
 	bytesPerRow := (m.Width + 7) / 8
 	byteIndex := y*bytesPerRow + x/8
 	bitIndex := uint(7 - (x % 8)) //nolint:gosec


### PR DESCRIPTION
Removed a TODO comment in `pkg/graphics/bitmap.go` asking to verify a linter suppression. The suppression was analyzed and found to be safe.

---
*PR created automatically by Jules for task [12197603812237184477](https://jules.google.com/task/12197603812237184477) started by @adcondev*